### PR TITLE
Improved logic to retrieve Deployment to use `app` label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved logic to determine Deployment to unidle to use `app`
   label. This makes the unidling more flexible and be used
   on more apps.
+- Improved wording and consistency of log messages
 
 
 ## [v0.0.3] - 2018-10-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v0.0.4] - 2018-10-10
+### Changed
+- Improved logic to determine Deployment to unidle to use `app`
+  label. This makes the unidling more flexible and be used
+  on more apps.
+
+
 ## [v0.0.3] - 2018-10-10
 ### Changed
 - Improved wording of response when unidling failed.

--- a/app.go
+++ b/app.go
@@ -71,12 +71,13 @@ func (a *App) Unidle() error {
 }
 
 func (a *App) getIngress() error {
-	opts := metav1.ListOptions{
+	listOptions := metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("metadata.name!=%s", UNIDLER),
+		LabelSelector: "app",
 	}
 
 	// NOTE: can't filter by spec.rules[0].host
-	list, err := a.Config.K8s.ExtensionsV1beta1().Ingresses("").List(opts)
+	list, err := a.Config.K8s.ExtensionsV1beta1().Ingresses("").List(listOptions)
 	if err != nil {
 		return err
 	}
@@ -96,10 +97,7 @@ func (a *App) getIngress() error {
 //
 // This is the deployment with `app` label as in ingress
 func (a *App) getDeployment() error {
-	appLabel, ok := a.ingress.Labels["app"]
-	if !ok {
-		return fmt.Errorf("Ingress '%s' (ns: '%s') doesn't have 'app' label. Can't find matching Deployment without this label", a.ingress.Name, a.ingress.Namespace)
-	}
+	appLabel := a.ingress.Labels["app"]
 
 	listOptions := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("app=%s", appLabel),

--- a/app.go
+++ b/app.go
@@ -102,7 +102,7 @@ func (a *App) getDeployment() error {
 	}
 
 	listOptions := metav1.ListOptions{
-		FieldSelector: fmt.Sprint("app=%s", appLabel),
+		LabelSelector: fmt.Sprintf("app=%s", appLabel),
 	}
 	deployments, err := a.Config.K8s.Apps().Deployments(a.ingress.Namespace).List(listOptions)
 	if err != nil {


### PR DESCRIPTION
Instead of finding Deployment based on Ingress name we now use the `app` label on the Ingress to find the Deployment. This is useful as for example our Jupiter helm chart set the deployment to a name different than the ingress' name.

Also tweaked the wording of the log/error messages for consistency/clarity.