### PR TITLE
Delegate app service to unidler service

### DIFF
--- a/jsonpatch.go
+++ b/jsonpatch.go
@@ -61,6 +61,15 @@ func (p *JSONPatch) MarshalJSON() ([]byte, error) {
 	return json.Marshal(p.operations)
 }
 
+// Add contructs an Operation object to add the value at `path`
+func Add(path string, value interface{}) *Operation {
+	return &Operation{
+		Name:  "add",
+		Path:  path,
+		Value: value,
+	}
+}
+
 // Replace constructs an Operation object to replace the value at `path` with
 // `value`
 func Replace(path string, value interface{}) *Operation {

--- a/k8s.go
+++ b/k8s.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -21,6 +22,9 @@ type (
 
 	// Ingress wraps v1beta1.Ingress to add methods
 	Ingress v1beta1.Ingress
+
+	// Service wraps corev1.Service to add methods
+	Service corev1.Service
 )
 
 // KubernetesClient constructs a new Kubernetes client
@@ -66,19 +70,19 @@ func (dep *Deployment) Patch(k kubernetes.Interface, p ...*Operation) error {
 	return nil
 }
 
-// Patch applies a JSONPatch to an Ingress
-func (ing *Ingress) Patch(k kubernetes.Interface, p ...*Operation) error {
+// Patch applies a JSON patch to a Service
+func (svc *Service) Patch(k kubernetes.Interface, p ...*Operation) error {
 	bytes, err := json.Marshal(p)
 	if err != nil {
 		return fmt.Errorf("failed parsing patch: %s", err)
 	}
-	_, err = k.Extensions().Ingresses(ing.Namespace).Patch(
-		ing.Name,
+	_, err = k.CoreV1().Services(svc.Namespace).Patch(
+		svc.Name,
 		types.JSONPatchType,
 		bytes,
 	)
 	if err != nil {
-		return fmt.Errorf("failed patching ingress: %s", err)
+		return fmt.Errorf("failed patching service: %s", err)
 	}
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -74,8 +74,8 @@ gopkg.in/inf.v0
 gopkg.in/yaml.v2
 # k8s.io/api v0.0.0-20181130031204-d04500c8c3dd
 k8s.io/api/apps/v1
-k8s.io/api/extensions/v1beta1
 k8s.io/api/core/v1
+k8s.io/api/extensions/v1beta1
 k8s.io/api/apps/v1beta1
 k8s.io/api/admissionregistration/v1alpha1
 k8s.io/api/admissionregistration/v1beta1
@@ -108,10 +108,10 @@ k8s.io/api/storage/v1beta1
 # k8s.io/apimachinery v0.0.0-20181201231028-18a5ff3097b4
 k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/types
+k8s.io/apimachinery/pkg/util/intstr
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/pkg/runtime
 k8s.io/apimachinery/pkg/runtime/schema
-k8s.io/apimachinery/pkg/util/intstr
 k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/conversion
 k8s.io/apimachinery/pkg/fields


### PR DESCRIPTION
As discussed, instead of redirecting requests for the app hostname by re-enabling the app ingress and removing the hostname from the unidler ingress, modify the app service by:

* **Idling:** Change the app service to `type: ExternalName` with `externalName: unidler.default.svc.cluster.local` - essentially turning the app service into a proxy to the unidler

* **Unidling:** Change the app service back to `type: ClusterIP` with `selector: app=<app.name>` - turning the service back into a load balancer for the app pods

The major benefit of this change is that there is no race condition in modifying the Unidler ingress when multiple users are unidling apps concurrently.

**NOTE** - this depends on https://github.com/ministryofjustice/analytics-platform-idler/pull/29