### PR TITLE
Tweaks to Wording/Logging/Errors

### DIFF
--- a/app.go
+++ b/app.go
@@ -145,7 +145,7 @@ func (a *App) SetReplicas() (err error) {
 	idledAt, exists := a.deployment.Annotations[IdledAtAnnotation]
 	if !exists {
 		// no annotation means the app is not idled, so skip this step
-		a.log("Deployment had '%s' annotation. Assuming is already unidled.", IdledAtAnnotation)
+		a.log("Deployment don't have '%s' annotation. Assuming is already unidled.", IdledAtAnnotation)
 		return nil
 	}
 
@@ -211,9 +211,12 @@ func (a *App) RemoveIdledMetadata() (err error) {
 		a.log("Patch to remove idled metadata label/annotation failed: %s", err)
 
 		// ignore missing label or annotation
-		if !strings.Contains(err.Error(), "Unable to remove nonexistent key") {
-			return fmt.Errorf("Failed to remove idled metadata from your app.")
+		if strings.Contains(err.Error(), "Unable to remove nonexistent key") {
+			a.log("Ignored Deployment Patch error caused by nonexistent key")
+			return nil
 		}
+
+		return fmt.Errorf("Failed to remove idled metadata from your app.")
 	}
 
 	a.log("Successfully removed idled metadata (label/annotation) from Deployment.")

--- a/app.go
+++ b/app.go
@@ -189,7 +189,8 @@ func (a *App) RedirectService() error {
 
 	err := a.service.Patch(patch)
 	if err != nil {
-		return fmt.Errorf("failed redirecting service: %s", err)
+		a.log("failed redirecting service: %s", err)
+		return fmt.Errorf("Failed to redirect back your app.")
 	}
 
 	a.log("Successfully redirected Service back to app's pods.")

--- a/handlers.go
+++ b/handlers.go
@@ -46,7 +46,7 @@ func eventsHandler(w http.ResponseWriter, req *http.Request) {
 		sendError(s, err)
 		return
 	}
-	sendMessage(s, "3/6: Replicas restored. Waiting for app to be ready...")
+	sendMessage(s, "3/6: Replicas restored. Starting app. This could take a few minutes...")
 
 	err = app.WaitForDeployment()
 	if err != nil {

--- a/k8s.go
+++ b/k8s.go
@@ -59,7 +59,7 @@ func (d *Deployment) Patch(patch []byte) error {
 		patch,
 	)
 	if err != nil {
-		return fmt.Errorf("Patch on Deployment failed:: %s", err)
+		return fmt.Errorf("Patch on Deployment failed: %s", err)
 	}
 
 	return nil

--- a/templates/javascript.js
+++ b/templates/javascript.js
@@ -34,7 +34,9 @@
   };
 
   source.onerror = function (e) {
-    showFinalState("failure", e.data);
+    if (e.data !== undefined) {
+      showFinalState("failure", e.data);
+    }
   };
 
   source.addEventListener("success", function (e) {


### PR DESCRIPTION
- don't sent k8s error straight to the user when `Service.Patch()` failed: log it and send a nicer error to user, like we do in the rest of the service now (I missed this one)
- simplified logic when `Deployment.Patch()` fails because of `nonexistent key` error. Made the logs more accurate so that "successfully patched" is only when Patch didn't actually return an error
- fixed wording when an annotation is not found
- fixed double colon (`:`) typo 