### PR TITLE
Better error handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,25 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.12
+
+    working_directory: /go/src/github.com/ministryofjustice/analytics-platform-go-unidler
+
+    steps:
+      - checkout
+
+      - restore_cache: # restores saved cache if no changes are detected since last run
+          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
+          keys:
+            - v1-pkg-cache
+
+      - run:
+          name: Run unit tests
+          command: |
+            make test
+
+      - save_cache: # Store cache in the /go/pkg directory
+          key: v1-pkg-cache
+          paths:
+            - "/go/pkg"

--- a/app.go
+++ b/app.go
@@ -157,6 +157,11 @@ func (a *App) SetReplicas() (err error) {
 		num = 1
 	}
 
+	if num < 1 {
+		a.log("Original number of replicas was %d, assuming deployment had 1 replica when unidled: '%s=%s'.", num, IdledAtAnnotation, idledAt)
+		num = 1
+	}
+
 	replicas := int32(num)
 	patch := jp.Patch(
 		jp.Replace(jp.Path("spec", "replicas"), &replicas),

--- a/app.go
+++ b/app.go
@@ -194,7 +194,14 @@ func (a *App) RedirectService() error {
 
 	err := a.service.Patch(patch)
 	if err != nil {
-		a.log("failed redirecting service: %s", err)
+		a.log("Patch to Service failed: %s", err)
+
+		// ignore missing label or annotation
+		if strings.Contains(err.Error(), "Unable to remove nonexistent key") {
+			a.log("Ignored Service Patch error caused by nonexistent key.")
+			return nil
+		}
+
 		return fmt.Errorf("Failed to redirect back your app.")
 	}
 
@@ -217,7 +224,7 @@ func (a *App) RemoveIdledMetadata() (err error) {
 
 		// ignore missing label or annotation
 		if strings.Contains(err.Error(), "Unable to remove nonexistent key") {
-			a.log("Ignored Deployment Patch error caused by nonexistent key")
+			a.log("Ignored Deployment Patch error caused by nonexistent key.")
 			return nil
 		}
 


### PR DESCRIPTION
Try to do sensible things when possible:

- if idled annotation said app had `0` replicas when unidled, that's fishy and we should log it but assume original number of replicas was `1` instead: https://github.com/ministryofjustice/analytics-platform-go-unidler/commit/7efc609b8d974a30d71de4b8b852357e2dbd81a9
- log and handle better "nonexistent key" `Service` Patch error caused when user refresh or when `Ingress`change is slow to propagate and unidler try to do the work 2+ times. It's a transient error which will go away, user don't need to know about it: https://github.com/ministryofjustice/analytics-platform-go-unidler/commit/3a2155396bca7e3e8903850aa8d026621da2e040