### PR TITLE
Removed #/6 "progress" messages as confusing.

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -32,35 +32,35 @@ func eventsHandler(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	s.Flush()
 
-	sendMessage(s, "1/6: Starting unidling...")
+	sendMessage(s, "Starting unidling...")
 
 	app, err := NewApp(req.Host)
 	if err != nil {
 		sendError(s, err)
 		return
 	}
-	sendMessage(s, "2/6: App found. Unidling it...")
+	sendMessage(s, "App found. Unidling it...")
 
 	err = app.SetReplicas()
 	if err != nil {
 		sendError(s, err)
 		return
 	}
-	sendMessage(s, "3/6: Replicas restored. Starting app. This could take a few minutes...")
+	sendMessage(s, "Replicas restored. Starting app. This could take a few minutes...")
 
 	err = app.WaitForDeployment()
 	if err != nil {
 		sendError(s, err)
 		return
 	}
-	sendMessage(s, "4/6: App ready. Removing idled metadata...")
+	sendMessage(s, "App ready. Removing idled metadata...")
 
 	err = app.RemoveIdledMetadata()
 	if err != nil {
 		sendError(s, err)
 		return
 	}
-	sendMessage(s, "5/6: Redirecting app...")
+	sendMessage(s, "Redirecting app...")
 
 	err = app.RedirectService()
 	if err != nil {


### PR DESCRIPTION
I thought they were good enough. Users got confused. My bad.

Removing the numbers as some users with knowledge of k8s confused
them to number of pods/replicas because of the "replicas restore" wording which makes
the numbers ambiguous.

😭

FYI: @r4vi This was in PR #7 but it got lost when I pushed the other changes. No need to review (but of course feel free to have a look), I'm merging it.