### PR TITLE
Use `host` labels to simplify filtering logic

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -79,7 +79,7 @@ func TestRedirectService(t *testing.T) {
 func TestRemoveIdledMetadata(t *testing.T) {
 	// Check: We have idled metadata
 	assert.True(t, hasIdledLabel(deploy))
-	assert.True(t, hasIdledAtAnnotation(deploy))
+	assert.True(t, hasReplicasAnnotation(deploy))
 
 	err := app.RemoveIdledMetadata()
 
@@ -87,7 +87,7 @@ func TestRemoveIdledMetadata(t *testing.T) {
 	deploy = getDeployment(NS, NAME)
 	// XXX fake patch doesn't remove
 	// assert.False(t, hasIdledLabel(deploy))
-	// assert.False(t, hasIdledAtAnnotation(deploy))
+	// assert.False(t, hasReplicasAnnotation(deploy))
 }
 
 func hasIdledLabel(deploy Deployment) bool {
@@ -95,8 +95,8 @@ func hasIdledLabel(deploy Deployment) bool {
 	return ok
 }
 
-func hasIdledAtAnnotation(dep Deployment) bool {
-	_, ok := deploy.Annotations[IdledAtAnnotation]
+func hasReplicasAnnotation(dep Deployment) bool {
+	_, ok := deploy.Annotations[ReplicasWhenUnidledAnnotation]
 	return ok
 }
 
@@ -115,7 +115,7 @@ func mockDeployment(client k8s.Interface, ns string, name string, host string) D
 	deploy, _ := client.Apps().Deployments(ns).Create(&appsAPI.Deployment{
 		ObjectMeta: metaAPI.ObjectMeta{
 			Annotations: map[string]string{
-				IdledAtAnnotation: "2018-12-10T12:34:56Z,1",
+				ReplicasWhenUnidledAnnotation: "1",
 			},
 			Name: name,
 			Labels: map[string]string{


### PR DESCRIPTION
This will mainly improve the retrieval of the `Ingress` as before this
we were getting almost ALL ingresses and then looping through them
to find the one `Ingress` resource we care about (the one for the app we're
unidling).

Also, started to use `mojanalytics.xyz/replicas-when-unidled` annotation. This is currently not written by the unidler but it's OK to use it here to simplify logic because:

1. idled tools have 1 replicas anyway (RStudio/JupyterLab)
2. we default to `1` replicas when this is not there