### PR TITLE
oopsy daisy: Removed `jsonpatch` from `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apk update \
 WORKDIR /go/src/github.com/ministryofjustice/analytics-platform-go-unidler
 
 COPY vendor/ vendor/
-COPY jsonpatch/ jsonpatch/
 COPY templates/ templates/
 COPY Makefile ./
 COPY *.go ./


### PR DESCRIPTION
We got rid of this package now so try to copy its files to build the image cause an error.