### PR TITLE
Fix long domains causing `host` label to exceed 63 chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,91 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v1.0.3] - 2019-10-28
+### Changed
+Truncate `host` labels when more than 63 characters.
+
+This is a limit imposed by kubernetes and we're hitting this with the new
+domain. This label is used to find the app `Ingress`, `Deployment` and
+`Service`.
+
+Tools now truncate this label so we need to take this in account when
+unidling. For existing resources it shouldn't make any difference (as these
+labels wouldn't be longer than 63 characters)
+
+
+## [v1.0.2] - 2019-06-26
+### Fixed
+Fixed the Docker image build problem caused by the now deleted jsonpatch package.
+
+
+## [v1.0.1] - 2019-06-26
+### Changed
+Use strategic merge patch instead of brittle JSONPatch format.
+Strategic merge patch is more robust and less likely to raise an error on patch.
+
+For example we had problems where patching was failing while trying to remove
+a key from a map because the key was not there. Strategic merge patch would
+just work as that's the final/desired state.
+
+
+## [v1.0.0] - 2019-03-29
+### Changed
+- Leverage host labels to simplify retrieval of k8s resources for the app to
+  unidle
+- start to use replicas-when-unidled annotation
+
+
+## [v0.2.3] - 2019-03-21
+### Changed
+Removed #/6 "progress" messages as confusing
+
+
+## [v0.2.2] - 2019-03-21
+### Changed
+Tweaks to wording to avoid possible confusions and don't show errors we can handle to users.
+
+
+## [v0.2.1] - 2019-03-14
+### Changed
+**Better handling of connection errors and wording tweaks**
+- treat connection errors differently: e.g. don't show undefined message and
+  don't close EventSource to allow recover
+- tell the user that wait for the deployment could take minutes
+- don't send low-level k8s error to user when Service.Patch() failed
+- improved logging messages to be more accurate of what actually happened
+
+
+## [v0.2.0] - 2019-03-13
+### Fixed
+**Fix for undefined error while unidiling**
+- fix for JS error undefined that we think it may have been caused by the
+  unidler restoring the service too early in the unidling process
+- users get more updates on the process, not just the bad news
+- fixed white space between last message and image
+- more logging
+- refactorings and cleanups
+
+See PR for full diff
+
+Issue: ministryofjustice/analytics-platform#95
+PR: https://github.com/ministryofjustice/analytics-platform-go-unidler/pull/5
+
+
+## [v0.1.0] - 2019-01-24
+### Changed
+**Redirect Service instead of Ingress**
+Requests to idled apps will receive an HTML page with dynamically updated
+status of the unidling process
+
+
+## [v0.0.5] - 2019-01-24
+### Changed
+**Report unidling progress**
+Requests to idled apps will receive an HTML page with dynamically updated
+status of the unidling process.
+
+
 ## [v0.0.4] - 2018-10-10
 ### Changed
 - Improved logic to determine Deployment to unidle to use `app`

--- a/app.go
+++ b/app.go
@@ -67,11 +67,22 @@ func (a *App) log(format string, args ...interface{}) {
 	a.logger.Printf("%s: %s", a.host, fmt.Sprintf(format, args...))
 }
 
+func truncateLabel(label string) string {
+	// k8s labels can be max 63 characters
+	const maxLabelLength = 63
+
+	if len(label) > maxLabelLength {
+		return label[0:maxLabelLength]
+	}
+
+	return label
+}
+
 // GetIngress returns the ingress for the app
 func (a *App) GetIngress() (*Ingress, error) {
 	// Get ingresses with app host label
 	ings, err := k8sClient.ExtensionsV1beta1().Ingresses("").List(metaAPI.ListOptions{
-		LabelSelector: fmt.Sprintf("host=%s", a.host),
+		LabelSelector: fmt.Sprintf("host=%s", truncateLabel(a.host)),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed listing ingresses: %s", err)
@@ -91,7 +102,7 @@ func (a *App) GetIngress() (*Ingress, error) {
 func (a *App) GetDeployment() (*Deployment, error) {
 	deps, err := k8sClient.AppsV1().Deployments(a.ingress.Namespace).List(
 		metaAPI.ListOptions{
-			LabelSelector: fmt.Sprintf("host=%s", a.host),
+			LabelSelector: fmt.Sprintf("host=%s", truncateLabel(a.host)),
 		},
 	)
 	if err != nil {
@@ -111,7 +122,7 @@ func (a *App) GetDeployment() (*Deployment, error) {
 func (a *App) GetService() (*Service, error) {
 	svcs, err := k8sClient.CoreV1().Services(a.ingress.Namespace).List(
 		metaAPI.ListOptions{
-			LabelSelector: fmt.Sprintf("host=%s", a.host),
+			LabelSelector: fmt.Sprintf("host=%s", truncateLabel(a.host)),
 		},
 	)
 	if err != nil {

--- a/app_test.go
+++ b/app_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -169,4 +170,12 @@ func mockService(k k8s.Interface, ns string, name string, host string) Service {
 		},
 	})
 	return Service(*svc)
+}
+
+func TestTruncateLabel(t *testing.T) {
+	short := "example.com"
+	long := strings.Repeat("x", 100)
+
+	assert.Equal(t, truncateLabel(short), short)
+	assert.Equal(t, truncateLabel(long), long[0:63])
 }


### PR DESCRIPTION
New domain will make the `host` label VERY LONG.
The tools now truncate the host label to 63 characters.

The `host` label is used by the unidler to find the app `Ingress`,
`Deployment` and `Service`.

This will make the unidler truncate the `host` label to match new resources
with long host label. For existing resources this will not make any
difference as they are less than 63 characters.

See PR to update tools helm charts: https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/395

Part of ticket: https://trello.com/c/kVT0QFqe