### PR TITLE
(long labels part 2) Use part before first "." as label selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ Builds and runs the unidler in a docker container
 ## Configuration
 The application doesn't require any configuration to work.
 
-| Env variable         | Default |  Details |
-| -------------------- | ------- | -------- |
-| `PORT`               | `:8080` | port on which the server listen |
+| Env variable         | Default  |  Details |
+| -------------------- | -------- | -------- |
+| `PORT`               | `:8080`  | port on which the server listen |
+| `UNIDLE_KEY_LABEL`   | `"host"` | label used to find kubernetes resources belonging to app to unidle. This is introduced to maintain compatibility with old `alpha` cluster. Set to `"unidle-key"` in new `prod`. **TODO**: Remove once `alpha` cluster is retired |
 
 **NOTE**: The server will try to load the kubernetes configuration from
 in-cluster first (this is the case when running the server within a k8s

--- a/main.go
+++ b/main.go
@@ -13,11 +13,15 @@ import (
 
 const DEFAULT_PORT = ":8080"
 
+// TODO: Remove once `alpha` cease to exist
+const DEFAULT_UNIDLE_KEY_LABEL = "host"
+
 var (
 	logger         *log.Logger
 	k8sClient      k8s.Interface
 	indexTemplates *template.Template
 	err            error
+	UnidleKeyLabel string
 )
 
 func init() {
@@ -44,6 +48,15 @@ func main() {
 	home, ok := os.LookupEnv("HOME")
 	if !ok {
 		logger.Fatalf("$HOME not set. It couldn't determine HOME directory.")
+	}
+
+	// NOTE: Default to `host` for retro-compatibility with `alpha` cluster
+	// TODO: Remove logic and always use `unidle-key` label once migration to
+	//       `prod`/new domain is completed
+	UnidleKeyLabel, ok = os.LookupEnv("UNIDLE_KEY_LABEL")
+	if !ok {
+		logger.Printf("$UNIDLE_KEY_LABEL not set. Defaulting to '%s'", DEFAULT_UNIDLE_KEY_LABEL)
+		UnidleKeyLabel = DEFAULT_UNIDLE_KEY_LABEL
 	}
 
 	k8sClient, err = KubernetesClient(filepath.Join(home, ".kube", "config"))


### PR DESCRIPTION
This is because k8s labels can't be longer than 63 chars and also they
can't end with a `.`

Introduced `UNIDLE_KEY_LABEL` environment variable to help with maintaining
compatibility with old `alpha` cluster.
This will default to `"host"` so that unidler will work as before in `alpha`.

Set `UNIDLE_KEY_LABEL=unidle-key` in new `prod` cluster to make the unidler
only use the part of the host before the first dot (".")

**NOTE**
This can be simpler once we sunset `alpha` and we don't need to honour
the `host` label and old behaviour anymore.

**PR with related helm charts changes**: https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/398/files

Ticket: https://trello.com/c/kVT0QFqe