### PR TITLE
Fix CSS classes so elements are hidden/shown correctly by JS.

### DIFF
--- a/templates/content.html
+++ b/templates/content.html
@@ -5,12 +5,12 @@
 
   <h2 class="govuk-heading-m" id="message"></h2>
 
-  <div id="success" class="hidden">
+  <div id="success" class="moj-hidden">
     <p class="govuk-body">The app was successfully unidled. You should be automatically redirected in a few seconds.</p>
     <p class="govuk-body">Otherwise, <a href="https://{{.}}/">go to the app</a>.</p>
   </div>
 
-  <div id="failure" class="hidden error-message">
+  <div id="failure" class="moj-hidden govuk-error-message">
     <p class="govuk-body">There was an issue unidling the app. Refreshing this page could resolve it.</p>
     <p class="govuk-body">If that's not the case, please contact the Analytical Platform team.</p>
   </div>

--- a/templates/javascript.js
+++ b/templates/javascript.js
@@ -24,7 +24,7 @@
     source.close();
 
     var elem = document.getElementById(finalState);
-    elem.classList.remove("hidden");
+    elem.classList.remove("moj-hidden");
 
     showMessage(finalMessage);
   }


### PR DESCRIPTION
This PR fixes a problem first noticed by Andy "eagle eyes" Lightfoot (@andylightfoot), where all the `divs` containing the various status messages were shown at the same time.

This PR updates the CSS classes to the correct GDS ones such that only one `div` is visible at a time and the JavaScript listener is able to update which message is shown depending on the status sent from the un-idler.